### PR TITLE
Removing redundant 'myDid' from authcryptable entities 

### DIFF
--- a/indy-wrapper/src/main/java/nl/quintor/studybits/Main.java
+++ b/indy-wrapper/src/main/java/nl/quintor/studybits/Main.java
@@ -92,8 +92,7 @@ public class Main {
         steward.anonDecrypt(newcomerConnectionResponse, ConnectionResponse.class)
                 .thenCompose(AsyncUtil.wrapException(steward::acceptConnectionResponse)).get();
 
-        AuthcryptedMessage verinym = newcomer.createVerinymRequest(JSONUtil.mapper.readValue(governmentConnectionRequest, ConnectionRequest.class).getDid())
-                .thenCompose(AsyncUtil.wrapException(newcomer::authcrypt)).get();
+        AuthcryptedMessage verinym = newcomer.authcrypt(newcomer.createVerinymRequest(JSONUtil.mapper.readValue(governmentConnectionRequest, ConnectionRequest.class).getDid())).get();
 
         steward.authDecrypt(verinym, Verinym.class)
                 .thenCompose(AsyncUtil.wrapException(steward::acceptVerinymRequest)).get();

--- a/indy-wrapper/src/main/java/nl/quintor/studybits/indy/wrapper/Issuer.java
+++ b/indy-wrapper/src/main/java/nl/quintor/studybits/indy/wrapper/Issuer.java
@@ -89,7 +89,6 @@ public class Issuer extends TrustAnchor {
                         wrapBiFunctionException((claimOfferJson, pairwiseResult) -> {
                             log.debug("{} Created claimOffer: {}", name, claimOfferJson);
                             ClaimOffer claimOffer = JSONUtil.mapper.readValue(claimOfferJson, ClaimOffer.class);
-                            claimOffer.setMyDid(pairwiseResult.getMyDid());
                             claimOffer.setTheirDid(targetDid);
                             log.debug("{} Created claimOffer object (toJSON()): {}", name, claimOffer.toJSON());
                             return claimOffer;
@@ -103,7 +102,6 @@ public class Issuer extends TrustAnchor {
                 .thenApply(wrapException((issuerCreateClaimResult) -> {
                     log.debug("{} Created claim json: {}", name, issuerCreateClaimResult.getClaimJson());
                     Claim claim = JSONUtil.mapper.readValue(issuerCreateClaimResult.getClaimJson(), Claim.class);
-                    claim.setMyDid(claimRequest.getMyDid());
                     claim.setTheirDid(claimRequest.getTheirDid());
                     return claim;
                 }));

--- a/indy-wrapper/src/main/java/nl/quintor/studybits/indy/wrapper/Prover.java
+++ b/indy-wrapper/src/main/java/nl/quintor/studybits/indy/wrapper/Prover.java
@@ -49,7 +49,6 @@ public class Prover extends WalletOwner {
                                     }));
                         })).thenApply(wrapException(claimRequestJson -> {
                             ClaimRequest claimRequest = JSONUtil.mapper.readValue(claimRequestJson, ClaimRequest.class);
-                            claimRequest.setMyDid(pairwiseResult.getMyDid());
                             claimRequest.setTheirDid(theirDid);
                             return claimRequest;
                         })))

--- a/indy-wrapper/src/main/java/nl/quintor/studybits/indy/wrapper/TrustAnchor.java
+++ b/indy-wrapper/src/main/java/nl/quintor/studybits/indy/wrapper/TrustAnchor.java
@@ -4,13 +4,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.extern.slf4j.Slf4j;
 import nl.quintor.studybits.indy.wrapper.dto.ConnectionRequest;
 import nl.quintor.studybits.indy.wrapper.dto.ConnectionResponse;
-import nl.quintor.studybits.indy.wrapper.dto.GetPairwiseResult;
 import nl.quintor.studybits.indy.wrapper.dto.Verinym;
 import nl.quintor.studybits.indy.wrapper.exception.IndyWrapperException;
-import nl.quintor.studybits.indy.wrapper.util.JSONUtil;
 import org.hyperledger.indy.sdk.IndyException;
-import org.hyperledger.indy.sdk.did.Did;
-import org.hyperledger.indy.sdk.pairwise.Pairwise;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -48,22 +44,10 @@ public class TrustAnchor extends WalletOwner {
                 );
     }
 
-    public CompletableFuture<Verinym> createVerinymRequest(String targetDid) throws IndyException, JsonProcessingException {
+    public Verinym createVerinymRequest(String targetDid) throws IndyException, JsonProcessingException {
         log.info("{} Creating verinym request for targetDid: {}", name, targetDid);
 
-        return Pairwise.getPairwise(wallet.getWallet(), targetDid)
-                .thenApply(wrapException((String getPairwiseResult) ->
-                        JSONUtil.mapper.readValue(getPairwiseResult, GetPairwiseResult.class)
-                ))
-                .thenCompose(wrapException((GetPairwiseResult getPairwiseResult) ->
-                        Did.keyForDid(pool.getPool(), wallet.getWallet(), getPairwiseResult.getMyDid())
-                                .thenApply(wrapException((myKey) -> {
-                                            Verinym result = new Verinym(wallet.getMainDid(), wallet.getMainKey(), getPairwiseResult.getMyDid(), targetDid);
-                                            log.debug("Created verinym {}", result);
-                                            return result;
-                                        }
-                                ))
-                ));
+        return new Verinym(wallet.getMainDid(), wallet.getMainKey(), targetDid);
     }
 
     public CompletableFuture<String> acceptVerinymRequest(Verinym verinym) throws IndyException {

--- a/indy-wrapper/src/main/java/nl/quintor/studybits/indy/wrapper/WalletOwner.java
+++ b/indy-wrapper/src/main/java/nl/quintor/studybits/indy/wrapper/WalletOwner.java
@@ -66,7 +66,7 @@ public class WalletOwner {
                         }));
     }
 
-    CompletableFuture<GetPairwiseResult> getPairwiseByTheirDid(String theirDid) throws IndyException {
+    public CompletableFuture<GetPairwiseResult> getPairwiseByTheirDid(String theirDid) throws IndyException {
         log.debug("{} Called getPairwise by their did: {}", name, theirDid);
         return Pairwise.getPairwise(wallet.getWallet(), theirDid)
                 .thenApply(wrapException(json -> JSONUtil.mapper.readValue(json, GetPairwiseResult.class)));

--- a/indy-wrapper/src/main/java/nl/quintor/studybits/indy/wrapper/dto/AuthCryptable.java
+++ b/indy-wrapper/src/main/java/nl/quintor/studybits/indy/wrapper/dto/AuthCryptable.java
@@ -2,7 +2,5 @@ package nl.quintor.studybits.indy.wrapper.dto;
 
 public interface AuthCryptable extends Serializable {
     String getTheirDid();
-    String getMyDid();
     void setTheirDid(String did);
-    void setMyDid(String did);
 }

--- a/indy-wrapper/src/main/java/nl/quintor/studybits/indy/wrapper/dto/Claim.java
+++ b/indy-wrapper/src/main/java/nl/quintor/studybits/indy/wrapper/dto/Claim.java
@@ -23,7 +23,5 @@ public class Claim implements Serializable, AuthCryptable {
     private Integer revReqSeqNo;
 
     @JsonIgnore
-    private String myDid;
-    @JsonIgnore
     private String theirDid;
 }

--- a/indy-wrapper/src/main/java/nl/quintor/studybits/indy/wrapper/dto/ClaimOffer.java
+++ b/indy-wrapper/src/main/java/nl/quintor/studybits/indy/wrapper/dto/ClaimOffer.java
@@ -20,8 +20,7 @@ public class ClaimOffer implements Serializable, AuthCryptable {
     private JsonNode keyCorrectnessProof;
 
     private String nonce;
-    @JsonIgnore
-    private String myDid;
+
     @JsonIgnore
     @Setter
     private String theirDid;

--- a/indy-wrapper/src/main/java/nl/quintor/studybits/indy/wrapper/dto/ClaimRequest.java
+++ b/indy-wrapper/src/main/java/nl/quintor/studybits/indy/wrapper/dto/ClaimRequest.java
@@ -2,7 +2,6 @@ package nl.quintor.studybits.indy.wrapper.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -27,8 +26,6 @@ public class ClaimRequest implements Serializable, AuthCryptable {
 
     private String nonce;
 
-    @JsonIgnore
-    private String myDid;
     @JsonIgnore
     private String theirDid;
 }

--- a/indy-wrapper/src/main/java/nl/quintor/studybits/indy/wrapper/dto/Verinym.java
+++ b/indy-wrapper/src/main/java/nl/quintor/studybits/indy/wrapper/dto/Verinym.java
@@ -10,8 +10,7 @@ import lombok.*;
 public class Verinym implements Serializable, AuthCryptable {
     private String did;
     private String verkey;
-    @JsonIgnore
-    private String myDid;
+
     @JsonIgnore
     @Setter
     private String theirDid;


### PR DESCRIPTION
I came across this while implementing #15, and this would simplify that issue as well.
Removing myDid simplifies the API. If needed, public calls for fine-grained did management can be added at some point.