### PR TITLE
Fixing exiting of build script

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e 
 docker-compose up --build --force-recreate --exit-code-from tests pool backend-university backend-student tests
 cd indy-wrapper
 docker-compose up --build --force-recreate --exit-code-from wrapper pool wrapper


### PR DESCRIPTION
This might be why we didn't notice test failure at some point (if the wrapper test succeeded, the exit code would be 0, regardless of whether the integration test failed)