### PR TITLE
Quindy as maven dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,1 @@
-[submodule "quindy"]
-	path = quindy
-	url = https://github.com/Quintor/quindy.git
+

--- a/.travis.sh
+++ b/.travis.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 set -e 
-docker build -t quindy:latest quindy/
 TEST_POOL_IP=127.0.0.1 docker-compose up --build --force-recreate --exit-code-from tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,5 @@
 version: '2.3'
 services:
-  quindy:
-    image: quindy
-    build: ./quindy
-    command: sh -c 'sleep 3000; exit 0'
   pool:
     build:
       context: ci

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,6 @@ services:
     - NL_QUINTOR_STUDYBITS_UNIVERSITY_NAME=Rijksuniversiteit Groningen
     - SPRING_PROFILES_ACTIVE=${SPRING_PROFILES:-mobile-test}
     depends_on:
-      quindy:
-        condition: service_started
       pool:
         condition: service_started
       university-agent-gent:
@@ -44,8 +42,6 @@ services:
     - SERVER_PORT=8081
     - SPRING_PROFILES_ACTIVE=${SPRING_PROFILES:-mobile-test}
     depends_on:
-      quindy:
-        condition: service_started
       pool:
         condition: service_started
     healthcheck:

--- a/university-agent/Dockerfile
+++ b/university-agent/Dockerfile
@@ -1,6 +1,3 @@
-FROM quindy:latest
-RUN mvn install -DskipTests
-
 FROM ubuntu:16.04
 # First install software-properties-common for add-apt-repository, and apt-transport-https to communicate.
 RUN apt-get update \
@@ -20,12 +17,6 @@ ARG LIBINDY_VERSION=1.6.6
 
 # Split off libindy command for fast builds on version bump
 RUN apt-get update && apt-get install -y libindy=$LIBINDY_VERSION
-
-RUN mkdir /quindy
-COPY --from=0 /pom.xml /quindy/pom.xml
-COPY --from=0 /target/quindy-*-jar-with-dependencies.jar /quindy/quindy.jar
-
-RUN mvn install:install-file -Dfile=/quindy/quindy.jar  -DpomFile=/quindy/pom.xml
 
 ADD pom.xml /
 RUN mvn package

--- a/university-agent/pom.xml
+++ b/university-agent/pom.xml
@@ -17,6 +17,25 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <repositories>
+        <repository>
+            <snapshots>
+                <enabled>
+                    false
+                </enabled>
+            </snapshots>
+            <id>
+                bintray-quintor-quintor
+            </id>
+            <name>
+                bintray
+            </name>
+            <url>
+                https://dl.bintray.com/quintor/quintor
+            </url>
+        </repository>
+    </repositories>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -78,7 +97,7 @@
         <dependency>
             <groupId>nl.quintor</groupId>
             <artifactId>quindy</artifactId>
-            <version>0.1-SNAPSHOT</version>
+            <version>0.1.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>ch.qos.logback</groupId>
@@ -132,8 +151,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>
-                    <source>10</source>
-                    <target>10</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
                 <dependencies>
                     <dependency>


### PR DESCRIPTION
This PR:

- Introduces quindy 0.1.0 as dependency
- Removes the now-unused quindy submodule
- Should speed up build time, since the quindy docker image doesn't need to be built.